### PR TITLE
Remove breakpoint-sass from bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,8 +19,5 @@
     "presentation",
     "bright",
     "theme"
-  ],
-  "dependencies": {
-    "breakpoint-sass": "~2.4.2"
-  }
+  ]
 }


### PR DESCRIPTION
When bower uses to install this theme, it remove all sass files. I this case I think that "breakpoint-sass" is absolutely unnecessary.
